### PR TITLE
clobber-base.asd: missing dependency

### DIFF
--- a/Base/clobber-base.asd
+++ b/Base/clobber-base.asd
@@ -1,5 +1,5 @@
 (defsystem #:clobber-base
-  :depends-on ()
+  :depends-on (#:closer-mop)
   :serial t
   :components
   ((:file "packages")


### PR DESCRIPTION
The package `closer-mop`  is used but the system wasn't in the dependency.